### PR TITLE
Add User-Agent header to Discord HTTP request

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ async function newVideo(video,channel) {
 		path: '/api/webhooks/${config.webhook.channel}/${config.webook.token}',
 		method: 'POST',
 		headers: {
+			'User-Agent': 'Xisuma-Discord-YouTube (xisumavoid.com, 1.0.0)',
 			'Content-Type': 'application/json',
 			'Content-Length': Buffer.byteLength(JSON.stringify(data)),
 		},


### PR DESCRIPTION
Change proposed in this pull request:
* Added a `User-Agent` header for the webhook request to Discord. This is required as per [documentation](https://discordapp.com/developers/docs/reference#http-api).